### PR TITLE
Solution to No module named 'torchvision.transforms.functional_tensor' closes #18

### DIFF
--- a/orion/datasets/video_inference.py
+++ b/orion/datasets/video_inference.py
@@ -6,7 +6,6 @@ import sys
 
 import numpy as np
 import pandas as pd
-import pytorchvideo.transforms
 import skimage.draw
 import torch.utils.data
 from torchvision.transforms import v2


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix the import error by removing the reference to 'torchvision.transforms.functional_tensor'.