### PR TITLE
Add base scripts and adjustements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Orion is a Python-based application designed for video training and evaluation t
 
 ## Usage
 
-You can use Orion either through a Python script or directly in a Jupyter notebook.
+You can use Orion either through a Python script or build your own Jupyter notebook inspired by code samples in the `notebooks/` folder.
 
 ### Configuration file example
 
@@ -61,7 +61,7 @@ When configuring your model in the YAML file, ensure that the `frames` and `resi
 
 1. Prepare your configuration file in YAML format.
 
-1. Run the main script with torchrun:
+2. Run the main script with torchrun:
 
    ```bash
    torchrun --standalone --nnodes=1 --nproc-per-node=2 orion/utils/video_training_and_eval.py --config_path=notebooks/config/config.yaml
@@ -72,14 +72,27 @@ When configuring your model in the YAML file, ensure that the `frames` and `resi
 ### Using a Jupyter Notebook
 
 1. Prepare your configuration file in YAML format.
-1. In your Jupyter notebook, import necessary modules and set up environment variables.
-1. Define a class for your command-line arguments.
-1. Load your configuration, create transforms, initialize a wandb run, and run the main process.
+2. In your Jupyter notebook, import necessary modules and set up environment variables.
+3. Define a class for your command-line arguments.
+4. Load your configuration, create transforms, initialize a wandb run, and run the main process.
 
 ### Using Weights & Biases Sweeps
 
 1. Prepare your configuration and sweep configuration files in YAML format.
-1. In your Jupyter notebook, import necessary modules, define a function to load YAML configurations, and run the sweep agent.
+2. Run the `run_sweep.py` script to start the sweep agent (no argument needed - update the `sweep_conf_file_path` variable in the script to point to your sweep configuration file).
+   ```bash
+   python run_sweep.py
+   ```
+
+### Inference and Evaluation
+
+To run inference and evaluation, use the `run_inference.py` script.
+
+```bash
+python run_inference.py --config_path notebooks/config/config_x3d_multi_output_classification_eval.yaml --splits inference --model_path outputs/outputs_folder_id/best.pt
+```
+
+The other arguments are optional: the data path (usually defined in the config file), the output directory (usually defined in the config file), the wandb id & resume flag (both not needed for inference).
 
 ### Note
 

--- a/notebooks/config/config_x3d_binary_classification_rv_train.yaml
+++ b/notebooks/config/config_x3d_binary_classification_rv_train.yaml
@@ -1,0 +1,77 @@
+# Training parameters
+num_epochs: !!int 10
+model_name: !!str x3d_m
+data_filename: !!str /volume/orion_multi-class_multi-output/data/dev_set.csv
+output_dir: !!str "outputs"
+root: !!str "."
+datapoint_loc_label: !!str FileName
+label_loc_label: [RV_Alteration]
+binary_threshold: !!float 0.5
+use_amp: !!bool True
+frames: !!int 72
+device: !!str cuda
+period: !!int 2
+pretrained: !!bool True
+seed: !!int 0
+optimizer: !!str SGD
+weight_decay: !!float 0.00000049811877376642
+num_workers: !!int 8
+batch_size: !!int 4
+lr: !!float 0.0007008364943470314
+label_smoothing: !!null null
+label_smoothing_value: !!null null
+class_weights: !!null null
+
+# Loss and task configuration
+loss: !!str multi_head  # Use multi-head loss for multiple classification tasks
+task: !!str classification  # Indicates this is a multi-head classification model
+
+# Label mappings
+labels_map:
+  RV_Alteration:
+    "yes": !!int 1
+    "no": !!int 0
+
+# Head structure configuration
+head_structure:
+  RV_Alteration: !!int 1
+
+# Loss structure configuration
+loss_structure:
+  RV_Alteration: !!str bce_logit
+
+# Head weights configuration
+head_weights:
+  RV_Alteration: !!float 1.0
+
+# Scheduler configuration
+scheduler_type: !!str step
+factor: !!float 0.3
+patience: !!int 7
+threshold: !!float 0.01
+lr_step_period: !!int 15
+run_test: !!bool true
+tag: !!str filtered_deepRV_multihead_72_16_0.007
+project: !!str test_multi_head_classification
+entity: !!str mhi_ai
+resume: !!bool false 
+rand_augment: !!bool true
+resize: !!int 256
+apply_mask: !!bool false
+view_count: !!null null
+save_best: !!str loss
+
+# Wandb
+early_terminate:
+  type: !!str hyperband
+  min_iter: !!int 3
+
+# Metrics control
+metrics_control:
+  optim_thresh: !!str g_mean
+  plot_pred_distribution: !!bool true
+  plot_metrics_moving_thresh: !!bool true
+  n_bootstrap: !!int 100
+  q_bootstrap: !!float 0.05
+
+transforms: !!null null

--- a/notebooks/config/config_x3d_multi_output_classification_eval.yaml
+++ b/notebooks/config/config_x3d_multi_output_classification_eval.yaml
@@ -1,12 +1,12 @@
 # Training parameters
-num_epochs: !!int 10
+num_epochs: !!int 1
 model_name: !!str x3d_m
-data_filename: !!str /volume/orion_multi-class_multi-output/data/dev_set.csv
+data_filename: !!str data/ObjectRecon_SWIN3D_2016-2023_inference_predictions_with_df_metadata_and_report_1000.csv
+mean: [120.905205, 120.905205, 120.905205]
+std: [40.97189, 40.97189, 40.97189]
 output_dir: !!str "outputs"
 root: !!str "."
 datapoint_loc_label: !!str FileName
-# label_loc_label: [contrast_agent, main_structure, stent_presence]
-label_loc_label: [RV_Alteration]
 binary_threshold: !!float 0.5
 use_amp: !!bool True
 frames: !!int 72

--- a/notebooks/config/config_x3d_multi_output_classification_train.yaml
+++ b/notebooks/config/config_x3d_multi_output_classification_train.yaml
@@ -5,8 +5,7 @@ data_filename: !!str /volume/orion_multi-class_multi-output/data/dev_set.csv
 output_dir: !!str "outputs"
 root: !!str "."
 datapoint_loc_label: !!str FileName
-# label_loc_label: [contrast_agent, main_structure, stent_presence]
-label_loc_label: [RV_Alteration]
+label_loc_label: [contrast_agent, main_structure, stent_presence]
 binary_threshold: !!float 0.5
 use_amp: !!bool True
 frames: !!int 72
@@ -29,21 +28,36 @@ task: !!str classification  # Indicates this is a multi-head classification mode
 
 # Label mappings
 labels_map:
-  RV_Alteration:
+  contrast_agent:
     "yes": !!int 1
     "no": !!int 0
+  main_structure:
+    Left Coronary: !!int 0
+    Right Coronary: !!int 1
+    Graft: !!int 2
+    Catheter: !!int 3
+    Femoral: !!int 4
+  stent_presence:
+    present: !!int 1
+    absent: !!int 0
 
 # Head structure configuration
 head_structure:
-  RV_Alteration: !!int 1
+  contrast_agent: !!int 1    # Binary classification (0 or 1)
+  main_structure: !!int 5    # Multi-class classification (5 classes)
+  stent_presence: !!int 1    # Binary classification (0 or 1)
 
 # Loss structure configuration
 loss_structure:
-  RV_Alteration: !!str bce_logit
+  contrast_agent: !!str bce_logit
+  main_structure: !!str ce
+  stent_presence: !!str bce_logit
 
 # Head weights configuration
 head_weights:
-  RV_Alteration: !!float 1.0
+  contrast_agent: !!float 1.0
+  main_structure: !!float 1.0
+  stent_presence: !!float 1.0
 
 # Scheduler configuration
 scheduler_type: !!str step

--- a/orion/utils/video_training_and_eval.py
+++ b/orion/utils/video_training_and_eval.py
@@ -938,13 +938,19 @@ def load_dataset(split, config, transforms, weighted_sampling):
     Returns:
         DataLoader: The DataLoader for the specified dataset split.
     """
-    if config["mean"] is None or config["std"] is None:
-        print("Error: 'mean' or 'std' values are missing.")
-        return None, None
+    missing_fields = []
+    if config["mean"] is None:
+        missing_fields.append("mean")
+    if config["std"] is None:
+        missing_fields.append("std")
+    if missing_fields:
+        raise ValueError(f"Error: The following fields are missing: {', '.join(missing_fields)}")
     else:
-        target_label = config.get("target_label", None)
+        target_label = config.get("label_loc_label", None)
         if config["task"] == "classification":
-            target_label = config.get("head_structure", None)
+            if config.get("head_structure", None) != target_label and split == "train":
+                raise ValueError("Error: head_structure does not match target_label")
+            
         kwargs = {
             "target_label": target_label,
             "mean": config["mean"],

--- a/run_inference.py
+++ b/run_inference.py
@@ -19,8 +19,9 @@ class Args:
     @staticmethod
     def verify_splits(splits: list[str]) -> list[str]:
         valid_splits = {'val', 'test', 'inference'}
-        invalid_splits = [split for split in splits if split not in valid_splits]
-        if invalid_splits:
+        if invalid_splits := [
+            split for split in splits if split not in valid_splits
+        ]:
             raise ValueError(
                 f"Invalid split(s): {invalid_splits}. "
                 f"Splits must be one or more of: {', '.join(valid_splits)}"

--- a/run_inference.py
+++ b/run_inference.py
@@ -1,0 +1,81 @@
+import argparse
+
+from dataclasses import dataclass
+
+from orion.utils.video_run_inference import run_inference
+
+
+@dataclass
+class Args:
+    config_path: str
+    splits: list[str]
+    log_wandb: bool
+    model_path: str
+    data_path: str
+    output_dir: str
+    wandb_id: str
+    resume: bool
+
+    @staticmethod
+    def verify_splits(splits: list[str]) -> list[str]:
+        valid_splits = {'val', 'test', 'inference'}
+        invalid_splits = [split for split in splits if split not in valid_splits]
+        if invalid_splits:
+            raise ValueError(
+                f"Invalid split(s): {invalid_splits}. "
+                f"Splits must be one or more of: {', '.join(valid_splits)}"
+            )
+        return splits
+
+    @classmethod
+    def parse_config(cls) -> 'Args':
+        parser = argparse.ArgumentParser(description="Run inference on a video dataset")
+        parser.add_argument("--config_path", type=str, required=True, help="Path to the config file")
+        parser.add_argument(
+            "--split", 
+            type=str, 
+            nargs='+', 
+            required=True, 
+            help="Splits to run inference on (e.g., --split test val inference)"
+        )
+        parser.add_argument("--log_wandb", type=bool, default=False, help="Log to wandb")
+        parser.add_argument("--model_path", type=str, default=None, help="Path to the model file")
+        parser.add_argument("--data_path", type=str, default=None, help="Path to the data file")
+        parser.add_argument("--output_dir", type=str, default=None, help="Path to the output directory")
+        parser.add_argument("--wandb_id", type=str, default=None, help="Wandb id")
+        parser.add_argument("--resume", type=bool, default=False, help="Resume training")
+        args = parser.parse_args()
+        
+        # Verify splits before creating the dataclass
+        verified_splits = cls.verify_splits(args.split)
+        
+        return cls(
+            config_path=args.config_path,
+            splits=verified_splits,
+            log_wandb=args.log_wandb,
+            model_path=args.model_path,
+            data_path=args.data_path,
+            output_dir=args.output_dir,
+            wandb_id=args.wandb_id,
+            resume=args.resume
+        )
+
+def main(args: Args):
+    df_dict = {}
+    for split in args.splits:
+        print(split)
+        df_dict[split] = run_inference(
+            config_path=args.config_path,
+            split=split,
+            log_wandb=args.log_wandb,
+            model_path=args.model_path,
+            data_path=args.data_path,
+            output_dir=args.output_dir,
+            wandb_id=args.wandb_id,
+            resume=args.resume,
+        )
+    return df_dict
+
+if __name__ == "__main__":
+    args: Args = Args.parse_config()
+    main(args)

--- a/run_sweep.py
+++ b/run_sweep.py
@@ -1,0 +1,29 @@
+import wandb
+import yaml
+
+
+def load_yaml_config(file_path):
+    with open(file_path, 'r') as file:
+        return yaml.safe_load(file)
+
+# Load sweep configuration
+sweep_conf_file_path = 'notebooks/config/sweep_config.yaml'
+sweep_conf = load_yaml_config(sweep_conf_file_path)
+
+# Number of runs to execute
+count = 1
+
+# Initialize the sweep
+sweep_id = wandb.sweep(
+    sweep=sweep_conf,
+    project="DeepRV_V2",
+    entity="jacques-delfrate"
+)
+
+# Start the sweep agent
+wandb.agent(
+    sweep_id=sweep_id,
+    project="DeepRV_V2",
+    entity="jacques-delfrate",
+    count=count
+)


### PR DESCRIPTION
# Summary
This PR introduces a foundational implementation of scripts to execute sweeps and perform inference, transitioning from the use of notebooks. Additionally, it incorporates a configuration file to facilitate inference using a multihead model on datasets with no labels and refines the error-checking logic within the `video_training_and_eval.py` script.

# Changed Introduced
1. Script-base sweep and Inference:
- Previous approach: No specific notebook for training and sweep.  
- New approach: Introduces command-line scripts to execute `run_sweep.py` and `run_inference.py`, enhancing usability
2.  Configuration File for Inference on Unlabeled Datasets `notebooks/config/config_x3d_multi_output_classification_eval.yaml`
3. Enhanced Error Checking in `video_training_and_eval.py`
- Fix logic error in `run_inference_and_log_to_wandb()` - we want to raise an error when both fonction params **and** config file are None. Not if one **or** the other.  Also prioritize function parameters over configuration file settings when both are provided by the user.
- Change error logic in `load_dataset()`
4. Updated README and related documentation to reflect the new script-based workflows and configuration options.

## Summary by Sourcery

New Features:
- Add scripts to run sweeps (`run_sweep.py`) and inference (`run_inference.py`).